### PR TITLE
fix: meta field in raw queries cannot be deleted for mariadb

### DIFF
--- a/src/dialects/mariadb/query.js
+++ b/src/dialects/mariadb/query.js
@@ -140,7 +140,6 @@ class Query extends AbstractQuery {
     }
     if (this.isRawQuery()) {
       const meta = data.meta;
-      delete data.meta;
       return [data, meta];
     }
     if (this.isShowIndexesQuery()) {


### PR DESCRIPTION
## Pull Request Checklist
- [ ] Have you added new tests to prevent regressions?
- [ ] If a documentation update is necessary, have you opened a PR to [the documentation repository](https://github.com/sequelize/website/)? <!-- Put PR link here -->
- [ ] Did you update the typescript typings accordingly (if applicable)?
- [ ] Does the description below contain a link to an existing issue (Closes #[issue]) or a description of the issue you are solving?
- [ ] Does the name of your PR follow [our conventions](https://github.com/sequelize/sequelize/blob/main/CONTRIBUTING.md#6-commit-your-modifications)?



## Description Of Change

In the context of the MariaDB dialect, the metadata field in rawQuery queries cannot be deleted.
The 'meta' property cannot be deleted because the 'data' object is actually an array.
Error Message (only rawQuery): TypeError: Cannot delete property 'meta' of [object Array]